### PR TITLE
Make env, components, and templates configurable

### DIFF
--- a/config
+++ b/config
@@ -7,6 +7,10 @@ cookie_secret   (generate)  : 10
 $api                        : /fapi/
 $customtitles               : true
 
+// env                         : dev
+// components                  : https://cdn.totaljs.com/flowstream/templates/db.json
+// templates                   : https://cdn.totaljs.com/flowstream/webcomponents/db.json
+
 // directory                   : /absolute/path/to/flow/database/
 
 // Disables: Worker/Fork

--- a/public/forms/templates.html
+++ b/public/forms/templates.html
@@ -83,7 +83,7 @@
 				});
 			};
 
-			queue.push(next => download('https://cdn.totaljs.com/flowstream/templates/db.json', next));
+			queue.push(next => download(common.templates, next));
 
 			queue.wait(function(fn, next) {
 				fn(next);

--- a/schemas/settings.js
+++ b/schemas/settings.js
@@ -128,17 +128,37 @@ ON('ready', function() {
 	else
 		PREF.name = CONF.name;
 
-	if (!PREF.env)
-		PREF.env = 'dev';
+	if (PREF.env) {
+		CONF.env = PREF.env;
+	} else {
+		if (CONF.env)
+			PREF.env = CONF.env;
+		else
+			PREF.env = 'dev';
+	}
 
 	if (PREF.backup)
 		CONF.backup = PREF.backup;
 
-	if (!PREF.components)
-		PREF.components = 'https://cdn.totaljs.com/flowstream/webcomponents/db.json';
+	if (PREF.components) {
+		CONF.components = PREF.components;
+	} else {
+		if (CONF.components) {
+			PREF.components = CONF.components;
+		} else {
+			PREF.components = 'https://cdn.totaljs.com/flowstream/webcomponents/db.json';
+		}
+	}
 
-	if (!PREF.templates)
-		PREF.templates = 'https://cdn.totaljs.com/flowstream/templates/db.json';
+	if (PREF.templates) {
+		CONF.templates = PREF.templates;
+	} else {
+		if (CONF.templates) {
+			PREF.templates = CONF.templates;
+		} else {
+			PREF.templates = 'https://cdn.totaljs.com/flowstream/templates/db.json';
+		}
+	}
 
 	if (!PREF.token)
 		PREF.token = GUID(30);


### PR DESCRIPTION
Hi,

this PR is an attempt to make the environment, the component database URL, and the template database URL configurable, similar to the way `CONF.name` is already handled.

It exposes the following variables in the `config` file:

- `env`: Can be set to either `dev`, `test`, or `prod`. Defaults to `dev`.
- `components`: The component database URL. Defaults to the Total.js CDN.
- `templates`: The template database URL. Defaults to the Total.js CDN.

Feel free to request or directly commit any changes!

Thanks in advance

Hauke